### PR TITLE
#51 Actualizar la fuente de datos tras la ejecución

### DIFF
--- a/DevAxRefreshData/DevAxRefreshData/AxClass/DevAxRefreshDataCopyWSParameters.xml
+++ b/DevAxRefreshData/DevAxRefreshData/AxClass/DevAxRefreshDataCopyWSParameters.xml
@@ -119,6 +119,7 @@ public class DevAxRefreshDataCopyWSParameters
         newRegister.CertificatePass = this.EInvoiceParameters.CertificatePass;
         newRegister.CertificateFile = this.EInvoiceParameters.CertificateFile;
         newRegister.ECertificateStr = this.EInvoiceParameters.ECertificateStr;
+        newRegister.CertificateUser = this.EInvoiceParameters.CertificateUser;
         newRegister.insert();
         ttsCommit;
 

--- a/DevAxRefreshData/DevAxRefreshData/AxClass/DevAxRefreshDataCopyWSParameters.xml
+++ b/DevAxRefreshData/DevAxRefreshData/AxClass/DevAxRefreshDataCopyWSParameters.xml
@@ -22,6 +22,9 @@ public class DevAxRefreshDataCopyWSParameters
             DevAxRefreshDataCopyWSParameters instance = new DevAxRefreshDataCopyWSParameters();
             instance.setselectedData(selectedData);
             instance.Run();
+            FormRun fr = _args.caller() as FormRun;
+            FormDataSource fds = fr.dataSource(tableStr(DevAxRefreshDataEInvoiceParameters));
+            fds.research(); // Refresh the data source to reflect the changes made
         }
     }
 

--- a/DevAxRefreshData/DevAxRefreshData/AxForm/DevAxRefreshData.xml
+++ b/DevAxRefreshData/DevAxRefreshData/AxForm/DevAxRefreshData.xml
@@ -220,13 +220,13 @@ public class DevAxRefreshData extends FormRun
 					<DataField>CertificatePass</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
+					<DataField>CertificateUser</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
 					<DataField>DataAreaId</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
 					<DataField>ECertificateStr</DataField>
-				</AxFormDataSourceField>
-				<AxFormDataSourceField>
-					<DataField>Key</DataField>
 				</AxFormDataSourceField>
 				<AxFormDataSourceField>
 					<DataField>Partition</DataField>
@@ -1341,6 +1341,15 @@ public class DevAxRefreshData extends FormRun
 														<FormControlExtension
 															i:nil="true" />
 														<DataField>CertificatePass</DataField>
+														<DataSource>DevAxRefreshDataEInvoiceParameters</DataSource>
+													</AxFormControl>
+													<AxFormControl xmlns=""
+														i:type="AxFormStringControl">
+														<Name>DevAxRefreshDataEInvoiceParameters_CertificateUser</Name>
+														<Type>String</Type>
+														<FormControlExtension
+															i:nil="true" />
+														<DataField>CertificateUser</DataField>
 														<DataSource>DevAxRefreshDataEInvoiceParameters</DataSource>
 													</AxFormControl>
 												</Controls>

--- a/DevAxRefreshData/DevAxRefreshData/AxTable/DevAxRefreshDataEInvoiceParameters.xml
+++ b/DevAxRefreshData/DevAxRefreshData/AxTable/DevAxRefreshDataEInvoiceParameters.xml
@@ -77,6 +77,12 @@ public class DevAxRefreshDataEInvoiceParameters extends common
 			<ExtendedDataType>AxxDocECertificateStr</ExtendedDataType>
 			<IgnoreEDTRelation>Yes</IgnoreEDTRelation>
 		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>CertificateUser</Name>
+			<ExtendedDataType>AxxDocCertificateUser</ExtendedDataType>
+			<IgnoreEDTRelation>Yes</IgnoreEDTRelation>
+		</AxTableField>
 	</Fields>
 	<FullTextIndexes />
 	<Indexes>


### PR DESCRIPTION
#51

Actualizar la fuente de datos tras la ejecución

Se añade funcionalidad para refrescar la fuente de datos
después de ejecutar `DevAxRefreshDataCopyWSParameters`.
Se obtiene el formulario llamador y su fuente de datos,
y se llama al método `research()` para reflejar los
cambios realizados.